### PR TITLE
NuGet package wording

### DIFF
--- a/src/EntityFrameworkCoreMock.Moq/EntityFrameworkCoreMock.Moq.csproj
+++ b/src/EntityFrameworkCoreMock.Moq/EntityFrameworkCoreMock.Moq.csproj
@@ -10,7 +10,7 @@
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/huysentruitw/entity-framework-core-mock</PackageProjectUrl>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-    <Description>Easy Mock wrapper for mocking EntityFrameworkCore 3 (EFCore3) DbContext and DbSet using Moq</Description>
+    <Description>Easy Mock wrapper for mocking EntityFrameworkCore 5 (EFCore5) DbContext and DbSet using Moq</Description>
     <Copyright>Copyright 2017-2020 Wouter Huysentruit</Copyright>
   </PropertyGroup>
 

--- a/src/EntityFrameworkCoreMock.NSubstitute/EntityFrameworkCoreMock.NSubstitute.csproj
+++ b/src/EntityFrameworkCoreMock.NSubstitute/EntityFrameworkCoreMock.NSubstitute.csproj
@@ -11,7 +11,7 @@
     <PackageProjectUrl>https://github.com/huysentruitw/entity-framework-core-mock</PackageProjectUrl>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <Description>Easy Mock wrapper for mocking EntityFrameworkCore 5 (EFCore5) DbContext and DbSet using NSubstitute</Description>
-    <Copyright>Copyright 2017-20139 Wouter Huysentruit, Paul Michaels</Copyright>
+    <Copyright>Copyright 2017-2020 Wouter Huysentruit, Paul Michaels</Copyright>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/EntityFrameworkCoreMock.NSubstitute/EntityFrameworkCoreMock.NSubstitute.csproj
+++ b/src/EntityFrameworkCoreMock.NSubstitute/EntityFrameworkCoreMock.NSubstitute.csproj
@@ -10,7 +10,7 @@
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/huysentruitw/entity-framework-core-mock</PackageProjectUrl>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-    <Description>Easy Mock wrapper for mocking EntityFrameworkCore 3 (EFCore3) DbContext and DbSet using NSubstitute</Description>
+    <Description>Easy Mock wrapper for mocking EntityFrameworkCore 5 (EFCore5) DbContext and DbSet using NSubstitute</Description>
     <Copyright>Copyright 2017-20139 Wouter Huysentruit, Paul Michaels</Copyright>
   </PropertyGroup>
 


### PR DESCRIPTION
EF Core 3 should not be referenced on NuGet.
- https://www.nuget.org/packages/EntityFrameworkCoreMock.NSubstitute/
- https://www.nuget.org/packages/EntityFrameworkCoreMock.Moq/