### PR TITLE
Handle property with a protected setter

### DIFF
--- a/src/EntityFrameworkCoreMock.Shared/DbSetBackingStore.cs
+++ b/src/EntityFrameworkCoreMock.Shared/DbSetBackingStore.cs
@@ -166,7 +166,7 @@ namespace EntityFrameworkCoreMock
         private static TEntity Clone(TEntity original) => CloneFuncCache.GetOrAdd(original.GetType(), CreateCloneFunc)(original);
         private static readonly ConcurrentDictionary<Type, Func<TEntity, TEntity>> CloneFuncCache = new ConcurrentDictionary<Type, Func<TEntity, TEntity>>();
         private static Func<TEntity, TEntity> CreateCloneFunc(Type entityType)
-        { 
+        {
             var properties = entityType.GetProperties(BindingFlags.Instance | BindingFlags.Public)
                 .Where(x => x.CanRead && x.CanWrite && x.GetCustomAttribute<NotMappedAttribute>() == null)
                 .Where(x => x.GetSetMethod() != null)

--- a/src/EntityFrameworkCoreMock.Shared/DbSetBackingStore.cs
+++ b/src/EntityFrameworkCoreMock.Shared/DbSetBackingStore.cs
@@ -149,6 +149,7 @@ namespace EntityFrameworkCoreMock
         {
             var properties = snapshot.GetType().GetProperties(BindingFlags.Instance | BindingFlags.Public)
                 .Where(x => x.CanRead && x.CanWrite && x.GetCustomAttribute<NotMappedAttribute>() == null)
+                .Where(x => x.GetSetMethod() != null)
                 .ToArray();
 
             return properties
@@ -165,9 +166,10 @@ namespace EntityFrameworkCoreMock
         private static TEntity Clone(TEntity original) => CloneFuncCache.GetOrAdd(original.GetType(), CreateCloneFunc)(original);
         private static readonly ConcurrentDictionary<Type, Func<TEntity, TEntity>> CloneFuncCache = new ConcurrentDictionary<Type, Func<TEntity, TEntity>>();
         private static Func<TEntity, TEntity> CreateCloneFunc(Type entityType)
-        {
+        { 
             var properties = entityType.GetProperties(BindingFlags.Instance | BindingFlags.Public)
                 .Where(x => x.CanRead && x.CanWrite && x.GetCustomAttribute<NotMappedAttribute>() == null)
+                .Where(x => x.GetSetMethod() != null)
                 .ToArray();
 
             var original = Expression.Parameter(typeof(TEntity), "original");

--- a/tests/EntityFrameworkCoreMock.Moq.Tests/DbContextMockTests.cs
+++ b/tests/EntityFrameworkCoreMock.Moq.Tests/DbContextMockTests.cs
@@ -119,7 +119,7 @@ namespace EntityFrameworkCoreMock.Tests
         {
             var dbContextMock = new DbContextMock<TestDbContext>(Options);
             Assert.DoesNotThrow(() => dbContextMock.CreateDbSetMock(x => 
-                x.ProtectedPropertyModels, (x, _) => x, new[] {new ProtectedSetterPropertyModel()}));
+                x.ProtectedSetterPropertyModels, (x, _) => x, new[] {new ProtectedSetterPropertyModel()}));
         }
 
         [Ignore("Not yet ported to EntityFrameworkCoreMock")]
@@ -244,7 +244,7 @@ namespace EntityFrameworkCoreMock.Tests
 
             public virtual DbSet<NoKeyModel> NoKeyModels { get; set; }
             
-            public virtual DbSet<ProtectedSetterPropertyModel> ProtectedPropertyModels { get; set; }
+            public virtual DbSet<ProtectedSetterPropertyModel> ProtectedSetterPropertyModels { get; set; }
 
             public virtual DbSet<GeneratedKeyModel> GeneratedKeyModels { get; set; }
 

--- a/tests/EntityFrameworkCoreMock.Moq.Tests/DbContextMockTests.cs
+++ b/tests/EntityFrameworkCoreMock.Moq.Tests/DbContextMockTests.cs
@@ -113,6 +113,14 @@ namespace EntityFrameworkCoreMock.Tests
             var dbContextMock = new DbContextMock<TestDbContext>(Options);
             Assert.DoesNotThrow(() => dbContextMock.CreateDbSetMock(x => x.NoKeyModels, (x, _) => x, new NoKeyModel[] { new NoKeyModel() }));
         }
+        
+        [Test]
+        public void DbContextMock_CreateDbSetMock_ModelWithProtectedProperties_ShouldNotThrowException()
+        {
+            var dbContextMock = new DbContextMock<TestDbContext>(Options);
+            Assert.DoesNotThrow(() => dbContextMock.CreateDbSetMock(x => 
+                x.ProtectedPropertyModels, (x, _) => x, new[] {new ProtectedSetterPropertyModel()}));
+        }
 
         [Ignore("Not yet ported to EntityFrameworkCoreMock")]
         public void DbContextMock_CreateDbSetMock_AddModelWithSameKeyTwice_ShouldThrowDbUpdatedException()
@@ -235,6 +243,8 @@ namespace EntityFrameworkCoreMock.Tests
             public virtual DbSet<User> Users { get; set; }
 
             public virtual DbSet<NoKeyModel> NoKeyModels { get; set; }
+            
+            public virtual DbSet<ProtectedSetterPropertyModel> ProtectedPropertyModels { get; set; }
 
             public virtual DbSet<GeneratedKeyModel> GeneratedKeyModels { get; set; }
 

--- a/tests/EntityFrameworkCoreMock.Moq.Tests/Models/ProtectedSetterPropertyModel.cs
+++ b/tests/EntityFrameworkCoreMock.Moq.Tests/Models/ProtectedSetterPropertyModel.cs
@@ -1,0 +1,7 @@
+﻿namespace EntityFrameworkCoreMock.Tests.Models
+{
+    public class ProtectedSetterPropertyModel
+    {
+        public string Protected { get; protected set; }
+    }
+}


### PR DESCRIPTION
We had an issue mocking a DbContext with models containing a property with a protected setter. For example:

```
public class Entity
{
    public DateTime CreationDate { get; protected set; }
    
    protected Entity()
    {
        CreationDate = DateTime.UtcNow;
    }
}
```

